### PR TITLE
Add local development env config

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Example configuration for local development
+BACKEND_PORT=5000
+FRONTEND_PORT=3000

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -8,21 +8,23 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-2. Copy the example environment file and add your OpenAI API key:
+2. Copy the example environment files and add your OpenAI API key:
 
 ```bash
 cp .env.example .env
-# edit .env
+cp .env.local.example .env.local
+cp src/frontend/.env.local.example src/frontend/.env.local
+# edit .env and .env.local files
 ```
 
-3. Start the backend server:
+3. Start the backend server (uses `BACKEND_PORT` from `.env.local`):
 
 ```bash
 cd src/backend
 python app.py
 ```
 
-4. In a separate terminal start the React frontend:
+4. In a separate terminal start the React frontend (uses `PORT` from `src/frontend/.env.local`):
 
 ```bash
 cd src/frontend
@@ -30,4 +32,4 @@ npm install
 npm start
 ```
 
-The application will be available at `http://localhost:3000` with the backend API running on `http://localhost:5000`.
+The application will be available at `http://localhost:$FRONTEND_PORT` with the backend API running on `http://localhost:$BACKEND_PORT` (configured in `.env.local`).

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 from flask import Flask, jsonify, request
@@ -64,4 +65,7 @@ def get_phrasebank(section: str):
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    # Use BACKEND_PORT from the environment when running locally.
+    # Defaults to 5000 which matches the frontend proxy configuration.
+    port = int(os.getenv("BACKEND_PORT", "5000"))
+    app.run(debug=True, port=port)

--- a/src/backend/openai_client.py
+++ b/src/backend/openai_client.py
@@ -3,7 +3,11 @@ import os
 import openai
 from dotenv import load_dotenv
 
+# Load the default environment file first and override with local
+# settings when available. This allows developers to keep local-only
+# configuration in `.env.local` which is ignored by git.
 load_dotenv()
+load_dotenv(".env.local", override=True)
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 openai.api_key = OPENAI_API_KEY

--- a/src/frontend/.env.local.example
+++ b/src/frontend/.env.local.example
@@ -1,0 +1,2 @@
+# Example frontend local configuration
+PORT=3000


### PR DESCRIPTION
## Summary
- load `.env.local` when available
- read `BACKEND_PORT` env var for flask app
- document `.env.local` usage for local setup
- provide example `.env.local` files for backend and frontend

## Testing
- `pytest -q` *(fails: command not found)*